### PR TITLE
fix: adjust menu order and enable tabs

### DIFF
--- a/src/js/isenabled.js
+++ b/src/js/isenabled.js
@@ -8,7 +8,7 @@ var IsEnabled = {
     addToHomeScreen: false,
     shareAd: false,
 
-    newsPage: false,
+    newsPage: true,
 
     chatsPage: false,
     chatPage: false,

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -62,11 +62,10 @@ const homePageRoute = function () {
 
   if (IsEnabled.servicesPage)
     tabs.push({
-      path: "/services/",
+      path: "/",
       id: "services",
       component: ServicesPage,
     });
-
   if (IsEnabled.newsPage)
     tabs.push({
       path: "/news/",
@@ -76,7 +75,7 @@ const homePageRoute = function () {
 
   if (IsEnabled.envPage)
     tabs.push({
-      path: "/",
+      path: "/env/",
       id: "env",
       component: EnvPage,
     });

--- a/src/pages/home.f7.html
+++ b/src/pages/home.f7.html
@@ -20,19 +20,18 @@
         {{#if isEnabled.servicesPage}}
           <a href="/" class="tab-link" data-route-tab-id="services"><i class="f7-icons">briefcase</i></a>
         {{/if}}
-        {{#if isEnabled.envPage}}
-          <a href="/env/" class="tab-link" data-route-tab-id="env"><i class="f7-icons">book</i></a>
+        {{#if isEnabled.scanPage}}
+          <a href="/scan/" class="tab-link" data-route-tab-id="scan"><i class="f7-icons">viewfinder</i></a>
         {{/if}}
         {{#if isEnabled.newsPage}}
           <a href="/news/" class="tab-link" data-route-tab-id="news"><i class="f7-icons">doc</i></a>
         {{/if}}
+        {{#if isEnabled.envPage}}
+          <a href="/env/" class="tab-link" data-route-tab-id="env"><i class="f7-icons">book</i></a>
+        {{/if}}
         {{#if isEnabled.auraPage}}
           <a href="/aura/" class="tab-link" data-route-tab-id="aura"><i class="f7-icons">largecircle_fill_circle</i></a>
         {{/if}}
-        {{#if isEnabled.scanPage}}
-          <a href="/scan/" class="tab-link" data-route-tab-id="scan"><i class="f7-icons">viewfinder</i></a>
-        {{/if}}
-
         {{#if isEnabled.chatsPage}}
           <a href="/chats/" class="tab-link" data-route-tab-id="chats"><i class="f7-icons">bubble_left </i></a>
         {{/if}}
@@ -44,17 +43,17 @@
         {{#if isEnabled.servicesPage}}
           <div class="page-content tab" id="services"></div>
         {{/if}}
-        {{#if isEnabled.envPage}}
-          <div class="page-content tab" id="env"></div>
+        {{#if isEnabled.scanPage}}
+          <div class="page-content tab" id="scan"></div>
         {{/if}}
         {{#if isEnabled.newsPage}}
           <div class="page-content tab" id="news"></div>
         {{/if}}
+        {{#if isEnabled.envPage}}
+          <div class="page-content tab" id="env"></div>
+        {{/if}}
         {{#if isEnabled.auraPage}}
           <div class="page-content tab" id="aura"></div>
-        {{/if}}
-        {{#if isEnabled.scanPage}}
-          <div class="page-content tab" id="scan"></div>
         {{/if}}
         {{#if isEnabled.chatsPage}}
           <div class="page-content tab" id="chats"></div>

--- a/src/pages/home.f7.html
+++ b/src/pages/home.f7.html
@@ -17,21 +17,22 @@
     <!-- Tabs toolbar -->
     <div class="toolbar tabbar toolbar-bottom">
       <div class="toolbar-inner">
-        {{#if isEnabled.envPage}}
-          <a href="/" class="tab-link" data-route-tab-id="env"><i class="f7-icons">book</i></a>
-        {{/if}}
-        {{#if isEnabled.scanPage}}
-          <a href="/scan/" class="tab-link" data-route-tab-id="scan"><i class="f7-icons">viewfinder</i></a>
-        {{/if}}
-        {{#if isEnabled.auraPage}}
-          <a href="/aura/" class="tab-link" data-route-tab-id="aura"><i class="f7-icons">largecircle_fill_circle</i></a>
-        {{/if}}
         {{#if isEnabled.servicesPage}}
-          <a href="/services/" class="tab-link" data-route-tab-id="services"><i class="f7-icons">briefcase</i></a>
+          <a href="/" class="tab-link" data-route-tab-id="services"><i class="f7-icons">briefcase</i></a>
+        {{/if}}
+        {{#if isEnabled.envPage}}
+          <a href="/env/" class="tab-link" data-route-tab-id="env"><i class="f7-icons">book</i></a>
         {{/if}}
         {{#if isEnabled.newsPage}}
           <a href="/news/" class="tab-link" data-route-tab-id="news"><i class="f7-icons">doc</i></a>
         {{/if}}
+        {{#if isEnabled.auraPage}}
+          <a href="/aura/" class="tab-link" data-route-tab-id="aura"><i class="f7-icons">largecircle_fill_circle</i></a>
+        {{/if}}
+        {{#if isEnabled.scanPage}}
+          <a href="/scan/" class="tab-link" data-route-tab-id="scan"><i class="f7-icons">viewfinder</i></a>
+        {{/if}}
+
         {{#if isEnabled.chatsPage}}
           <a href="/chats/" class="tab-link" data-route-tab-id="chats"><i class="f7-icons">bubble_left </i></a>
         {{/if}}
@@ -40,20 +41,20 @@
     <!-- Tabs content -->
     <div class="tabs-animated-wrap">
       <div class="tabs tabs-routable">
+        {{#if isEnabled.servicesPage}}
+          <div class="page-content tab" id="services"></div>
+        {{/if}}
         {{#if isEnabled.envPage}}
           <div class="page-content tab" id="env"></div>
         {{/if}}
-        {{#if isEnabled.scanPage}}
-          <div class="page-content tab" id="scan"></div>
+        {{#if isEnabled.newsPage}}
+          <div class="page-content tab" id="news"></div>
         {{/if}}
         {{#if isEnabled.auraPage}}
           <div class="page-content tab" id="aura"></div>
         {{/if}}
-        {{#if isEnabled.servicesPage}}
-          <div class="page-content tab" id="services"></div>
-        {{/if}}
-        {{#if isEnabled.newsPage}}
-          <div class="page-content tab" id="news"></div>
+        {{#if isEnabled.scanPage}}
+          <div class="page-content tab" id="scan"></div>
         {{/if}}
         {{#if isEnabled.chatsPage}}
           <div class="page-content tab" id="chats"></div>


### PR DESCRIPTION
Nesta issue foi ativado as telas que serão utilizadas no lançamento do app, e ordenado da seguinte forma

1. Serviços
2. QR Code
3. News
4. Env
5. Aura

fix: #133 