### PR TITLE
fix: api de produçao é utilizada quando necessário

### DIFF
--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -586,10 +586,6 @@ const storage = {
         headers: {
           Authorization: userToken
         }
-      }).catch((err) => {
-        storage.app.dialog.alert (
-          "Não foi possível desativar as notificações para este dispositivo, tente novamente mais tarde!"
-        );
       });
     });
   },

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -87,13 +87,24 @@ const storage = {
     let settings = localStorage["settings"];
 
     if (!settings) {
-      settings = {
-        offlineStorage: true,
-        allowNotifications: true,
-        // Dev options
-        devMode: true,
-        testApi: true,
-      };
+      const env = process.env.NODE_ENV || 'development';
+      if (env == 'production') {
+        settings = {
+          offlineStorage: true,
+          allowNotifications: true,
+          // Dev options
+          devMode: false,
+          testApi: false,
+        };
+      } else {
+        settings = {
+          offlineStorage: true,
+          allowNotifications: true,
+          // Dev options
+          devMode: true,
+          testApi: true,
+        };
+      }
       localStorage["settings"] = JSON.stringify(settings);
     } else {
       settings = JSON.parse(settings);

--- a/src/pages/settings.f7.html
+++ b/src/pages/settings.f7.html
@@ -169,8 +169,10 @@
           // Disable all dev options
           if (self.settings['devMode']) {
             app.dialog.confirm('Deseja realmente desativar o modo de desenvolvimento?', function () {
+              app.storage.clearAll()
               self.changeSetting('devMode', false)
               self.changeSetting('testApi', false)
+              app.view.main.router.navigate('/')
             })
           }
           // Enable dev options


### PR DESCRIPTION
Corrigi o problema que fazia com que a API de testes fossem utilizada mesmo na build de produção, também corrigi um bug que não fazia o logout quando o usuário mudava a api utilizada durante o uso do aplicativo o que gerava varios bugs já que os dados do usuário eram armazenados de acordo com a API anterior. 

Fix: #162 