### PR TITLE
Add camera permission and usesCleartextTraffic

### DIFF
--- a/cordova/config.xml
+++ b/cordova/config.xml
@@ -58,6 +58,12 @@
       <config-file parent="/manifest/application/" target="app/src/main/AndroidManifest.xml">
         <meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable/notification_icon" />
       </config-file>
+      <config-file parent="/manifest/" target="app/src/main/AndroidManifest.xml">
+        <uses-permission android:name="android.permission.CAMERA" />
+      </config-file>
+      <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
+        <application android:usesCleartextTraffic="true" />
+      </edit-config>
     </platform>
 
 


### PR DESCRIPTION
Foi adicionado tags na pasta `config.xml` que atualizam automaticamente a pasta `AndroidManifest.xml`, assim não será mais necessário se preocupar em add tags o manifest ao fazer build do app.

Fix: #194 