### PR TITLE
Feat: analytics (now we're using firebase analytics)

### DIFF
--- a/cordova/package-lock.json
+++ b/cordova/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "cc.uffs.practice",
-      "version": "0.4.0",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "cordova-ios": "^5.1.1",
@@ -17,7 +17,7 @@
         "cordova-plugin-wkwebview-file-xhr": "^2.1.4"
       },
       "devDependencies": {
-        "cordova-android": "^10.0.0",
+        "cordova-android": "^10.1.1",
         "cordova-plugin-androidx": "^3.0.0",
         "cordova-plugin-androidx-adapter": "^1.1.3",
         "cordova-plugin-badge": "^0.8.8",
@@ -186,9 +186,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/cordova-android": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-10.0.0.tgz",
-      "integrity": "sha512-EJyJxiBPRl8n8s9feUWT6y/qLLUyOtUj0aNfWCbDk6Qy88EZnGsTq6orE5kplmNMlF7cTpr0/ylrdxp3xHJE8w==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-10.1.1.tgz",
+      "integrity": "sha512-eoJp5AcDMHniqmxj0CbUF/rVQfbbp108TWKU6oyJW9rl/ZTJqZxm5ybznl+1/1MBksklxhMeipMn0Iwd0kEzEQ==",
       "dev": true,
       "dependencies": {
         "android-versions": "^1.7.0",
@@ -1753,9 +1753,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "cordova-android": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-10.0.0.tgz",
-      "integrity": "sha512-EJyJxiBPRl8n8s9feUWT6y/qLLUyOtUj0aNfWCbDk6Qy88EZnGsTq6orE5kplmNMlF7cTpr0/ylrdxp3xHJE8w==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-10.1.1.tgz",
+      "integrity": "sha512-eoJp5AcDMHniqmxj0CbUF/rVQfbbp108TWKU6oyJW9rl/ZTJqZxm5ybznl+1/1MBksklxhMeipMn0Iwd0kEzEQ==",
       "dev": true,
       "requires": {
         "android-versions": "^1.7.0",

--- a/cordova/package.json
+++ b/cordova/package.json
@@ -40,7 +40,8 @@
       "cordova-plugin-inappbrowser": {},
       "cordova-plugin-device": {},
       "cordova-plugin-vibration": {},
-      "cordova-plugin-screen-orientation": {}
+      "cordova-plugin-screen-orientation": {},
+      "cordova-plugin-firebase-analytics": {}
     },
     "platforms": [
       "ios",
@@ -48,7 +49,7 @@
     ]
   },
   "devDependencies": {
-    "cordova-android": "^10.0.0",
+    "cordova-android": "^10.1.1",
     "cordova-plugin-androidx": "^3.0.0",
     "cordova-plugin-androidx-adapter": "^1.1.3",
     "cordova-plugin-badge": "^0.8.8",

--- a/src/js/api.js
+++ b/src/js/api.js
@@ -20,8 +20,8 @@ export class Api {
             "password": password,
             "app_id": "1"
         }).then( async (res) => {
-            let data = JSON.parse(res.data);
-            app.storage.setUserData(data.user);
+			let data = JSON.parse(res.data);
+			app.storage.setUserData(data.user);
             if (data.passport) {
                 app.storage.setUserCredentials(data);
                 app.request.setup({

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -12,76 +12,89 @@ import cordovaApp from './cordova-app.js';
 // Import Routes
 import routes from './routes.js';
 // Import analytics stuff 
-import Abalytics from './abalytics.js';
+import {Abalytics} from './abalytics.js';
 
-import { Api } from './api';
-import { Checkin } from './checkin';
-import { Storage } from './storage.js';
-import { QrCodeResponder } from './qrCodeResponder.js';
-import { Aura } from './aura';
+import {
+	Api
+} from './api';
+import {
+	Checkin
+} from './checkin';
+import {
+	Storage
+} from './storage.js';
+import {
+	QrCodeResponder
+} from './qrCodeResponder.js';
+import {
+	Aura
+} from './aura';
 
 // Import main app component
 import App from '../app.f7.html';
 
 var app = new Framework7({
-  root: '#app', // App root element
-  component: App, // App main component
-  id: 'cc.uffs.practice', // App bundle ID
-  name: 'PRACTICE', // App name
-  theme: 'auto', // Automatic theme detection
+	root: '#app', // App root element
+	component: App, // App main component
+	id: 'cc.uffs.practice', // App bundle ID
+	name: 'PRACTICE', // App name
+	theme: 'auto', // Automatic theme detection
 
-  // App routes
-  routes: routes,
+	// App routes
+	routes: routes,
 
-  // Register service worker
-  serviceWorker: Framework7.device.cordova ? {} : {
-    path: '/service-worker.js',
-  },
+	// Register service worker
+	serviceWorker: Framework7.device.cordova ? {} : {
+		path: '/service-worker.js',
+	},
 
-  // Input settings
-  input: {
-    scrollIntoViewOnFocus: Framework7.device.cordova && !Framework7.device.electron,
-    scrollIntoViewCentered: Framework7.device.cordova && !Framework7.device.electron,
-  },
-  
-  // Cordova Statusbar settings
-  statusbar: {
-    iosOverlaysWebView: true,
-    androidOverlaysWebView: false,
-  },
+	// Input settings
+	input: {
+		scrollIntoViewOnFocus: Framework7.device.cordova && !Framework7.device.electron,
+		scrollIntoViewCentered: Framework7.device.cordova && !Framework7.device.electron,
+	},
 
-  // Touch options
-  touch: {
-    tapHold: true,
-  },
+	// Cordova Statusbar settings
+	statusbar: {
+		iosOverlaysWebView: true,
+		androidOverlaysWebView: false,
+	},
 
-  on: {
-    init: function() {
-      var f7 = this;
-      f7.$$ = Dom7;
-      
-      if (f7.device.cordova) {
-        // Init cordova APIs (see cordova-app.js)
-        cordovaApp.init(f7)
-      } else {
-        // Save context to allow 'Add to home screen'
-        f7.deferredInstallPrompt = null
+	// Touch options
+	touch: {
+		tapHold: true,
+	},
 
-        window.addEventListener('beforeinstallprompt', function(e) {
-          // Stash the event so it can be triggered later.
-          f7.deferredInstallPrompt = e
-          console.log('Saving beforeinstallprompt: ', e)
-        })
-      }
+	on: {
+		init: function () {
+			var f7 = this;
+			f7.$$ = Dom7;
 
-      window.screen.orientation.lock('portrait');
+			if (f7.device.cordova) {
+				// Init cordova APIs (see cordova-app.js)
+				cordovaApp.init(f7)
+			} else {
+				// Save context to allow 'Add to home screen'
+				f7.deferredInstallPrompt = null
 
-      Abalytics.init(f7)
-      new Storage(f7);
-      new Api(f7);
-      new Checkin(f7);
-      new QrCodeResponder(f7);
-      new Aura(f7);
-    },
-  },
+				window.addEventListener('beforeinstallprompt', function (e) {
+					// Stash the event so it can be triggered later.
+					f7.deferredInstallPrompt = e
+					console.log('Saving beforeinstallprompt: ', e)
+				})
+			}
+
+			window.screen.orientation.lock('portrait');
+
+			if (typeof cordova !== 'undefined') {
+				new Abalytics(f7);
+			}
+
+			new Storage(f7);
+			new Api(f7);
+			new Checkin(f7);
+			new QrCodeResponder(f7);
+			new Aura(f7);
+		},
+	},
 })

--- a/src/js/aura.js
+++ b/src/js/aura.js
@@ -10,7 +10,14 @@ export class Aura{
 
         let encodeInput = encodeURI(input);
         return await app.request.promise.get(app.api.url + "aura/nlp/qna/" + encodeInput)
-        .then(async (res) => {
+		.then(async (res) => {
+			if (typeof cordova !== 'undefined') {
+				cordova.plugins.firebase.analytics.logEvent("aura", {
+					"request_answer": input
+				}).then(res => {
+					console.log(`[${res}] aura: request_answer=${input}`);
+				})
+			}
             let data = JSON.parse(res.data);
             return data.answer;
         }).catch(err => err);

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -1,7 +1,9 @@
 export class Storage {
 	constructor(app) {
 		this.prodApiURL = "https://practice.uffs.edu.br/api/v0/";
-		this.testApiURL = "https://api.practice.uffs.cc/v0";
+		// this.testApiURL = "https://api.practice.uffs.cc/v0";
+		this.testApiURL = "https://practice.uffs.edu.br/api/v0/";
+
 		this.app = app;
 		app.storage = this;
 	}

--- a/src/pages/aura.f7.html
+++ b/src/pages/aura.f7.html
@@ -1,284 +1,305 @@
 <template>
-  <div data-name="aura" id="tab_aura" style="height: 100%;">
+	<div data-name="aura" id="tab_aura" style="height: 100%;">
 
-    <div id="logo_aura">
-      <img src="static/images/aura/aura_logo.png" alt="" width="40%">
-    </div>
-    
-    <div class="page-content messages-content">
-      <div class="messages">
-      </div>  
-    </div>
-    
-    <div class="aura-consent-buttons padding-left padding-right justify-content-space-between">
-        <button class="margin-right button button-raised" @click="auraConsentAnswer(false)">Discordo</button>
-        <button class="margin-left button button-fill button-raised" @click="auraConsentAnswer(true)">Concordo</button>
-    </div>
-    <div class="toolbar messagebar">
-      <div class="toolbar-inner">
-        <div class="messagebar-area">
-          <textarea placeholder="Digite uma mensagem"></textarea>
-        </div>
-        <a class="link send-link" href="#"><span><i class="icon f7-icons theme-color-2">arrowtriangle_right_fill</i></span></a>
-      </div>
-    </div>
-  </div>
+		<div id="logo_aura">
+			<img src="static/images/aura/aura_logo.png" alt="" width="40%">
+		</div>
+
+		<div class="page-content messages-content">
+			<div class="messages">
+			</div>
+		</div>
+
+		<div class="aura-consent-buttons padding-left padding-right justify-content-space-between">
+			<button class="margin-right button button-raised" @click="auraConsentAnswer(false)">Discordo</button>
+			<button class="margin-left button button-fill button-raised"
+				@click="auraConsentAnswer(true)">Concordo</button>
+		</div>
+		<div class="toolbar messagebar">
+			<div class="toolbar-inner">
+				<div class="messagebar-area">
+					<textarea placeholder="Digite uma mensagem"></textarea>
+				</div>
+				<a class="link send-link" href="#"><span><i
+							class="icon f7-icons theme-color-2">arrowtriangle_right_fill</i></span></a>
+			</div>
+		</div>
+	</div>
 </template>
 
-<style>  
-  .messages-content {
-    padding-bottom : 0px;
-    padding-top : 0px;
-  }
-  .aura-consent-buttons {
-    padding-bottom: 10px;
-    display: none;
-    background-color: #fff;
-  }
-  #logo_aura {
-    position: absolute;
-    padding: 20px 0px;
-    z-index: 3;
-    text-align: center;
-    width: 100%;
-    background-image: linear-gradient(to bottom, white, white, rgba(255,255,255,0.8),rgba(255,255,255,0));
-  }
+<style>
+	.messages-content {
+		padding-bottom: 0px;
+		padding-top: 0px;
+	}
+
+	.aura-consent-buttons {
+		padding-bottom: 10px;
+		display: none;
+		background-color: #fff;
+	}
+
+	#logo_aura {
+		position: absolute;
+		padding: 20px 0px;
+		z-index: 3;
+		text-align: center;
+		width: 100%;
+		background-image: linear-gradient(to bottom, white, white, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+	}
 </style>
 
 <script>
-  import 'dom7/dist/dom7.js';
+	import 'dom7/dist/dom7.js';
 
-  export default {
-    data: function () {
-      return {
-        chat: null,
-        messages : null
-      }
-    },
-    methods: {
-      getTimestamp: function () {
-        var date = new Date();
-        var time = date.toTimeString().substring(0,5);
-        return time;
-      },
-      getAuraAnswer: async function (input) {
-        var self = this;
-        var app = self.$app;
+	export default {
+		data: function () {
+			return {
+				chat: null,
+				messages: null
+			}
+		},
+		methods: {
+			getTimestamp: function () {
+				var date = new Date();
+				var time = date.toTimeString().substring(0, 5);
+				return time;
+			},
+			getAuraAnswer: async function (input) {
+				var self = this;
+				var app = self.$app;
 
-        return app.aura.requestAnswer(input).then((answer) => {
-          if(answer){
-            answer = answer.replace(/(Minerva)/gi, 'Aura');
-          }
-          return answer;
-        });
-      },
-      resizeMessagesContent: function (){
-        let logoAura = Dom7('#logo_aura');
-        let aura = Dom7('#tab_aura');
-        let messagebar = Dom7('.messagebar');
-        let messagesContent = Dom7('.messages-content');
-        let height = aura.height() - messagebar.height() + 'px';
-        messagesContent.css('height', height);
-        messagesContent.css('padding-top', logoAura.height() + 10 + 'px');
-      },
-      messageInit: function () {
-        var self = this;
-        var app = self.$app;
-        var $$ = Dom7;
+				return app.aura.requestAnswer(input).then((answer) => {
+					if (answer) {
+						answer = answer.replace(/(Minerva)/gi, 'Aura');
+					}
+					return answer;
+				});
+			},
+			resizeMessagesContent: function () {
+				let logoAura = Dom7('#logo_aura');
+				let aura = Dom7('#tab_aura');
+				let messagebar = Dom7('.messagebar');
+				let messagesContent = Dom7('.messages-content');
+				let height = aura.height() - messagebar.height() + 'px';
+				messagesContent.css('height', height);
+				messagesContent.css('padding-top', logoAura.height() + 10 + 'px');
+			},
+			messageInit: function () {
+				var self = this;
+				var app = self.$app;
+				var $$ = Dom7;
 
-        self.messages = app.messages.create({
-          el: '.messages',
+				self.messages = app.messages.create({
+					el: '.messages',
 
-          firstMessageRule: function (message, previousMessage, nextMessage) {
-            if (message.isTitle) return false;
+					firstMessageRule: function (message, previousMessage, nextMessage) {
+						if (message.isTitle) return false;
 
-            if (!previousMessage || previousMessage.type !== message.type || previousMessage.name !== message.name) return true;
-            return false;
-          },
+						if (!previousMessage || previousMessage.type !== message.type || previousMessage
+							.name !== message.name) return true;
+						return false;
+					},
 
-          lastMessageRule: function (message, previousMessage, nextMessage) {
-            if (message.isTitle) return false;
-            
-            if (!nextMessage || nextMessage.type !== message.type || nextMessage.name !== message.name) return true;
-            return false;
-          },
+					lastMessageRule: function (message, previousMessage, nextMessage) {
+						if (message.isTitle) return false;
 
-          tailMessageRule: function (message, previousMessage, nextMessage) {
-            if (message.isTitle) return false;
-            
-            if (!nextMessage || nextMessage.type !== message.type || nextMessage.name !== message.name) return true;
-            return false;
-          }
-        });
+						if (!nextMessage || nextMessage.type !== message.type || nextMessage.name !==
+							message.name) return true;
+						return false;
+					},
 
-        var messagebar = app.messagebar.create({
-          el: '.messagebar'
-        });
+					tailMessageRule: function (message, previousMessage, nextMessage) {
+						if (message.isTitle) return false;
 
-        var responseInProgress = false;
+						if (!nextMessage || nextMessage.type !== message.type || nextMessage.name !==
+							message.name) return true;
+						return false;
+					}
+				});
 
-        $$('.send-link').on('click', function () {
-          var text = messagebar.getValue().replace(/\n/g, '<br>').trim();
-          if (!text.length) return;
+				var messagebar = app.messagebar.create({
+					el: '.messagebar'
+				});
 
-          messagebar.clear();
-          messagebar.focus();
+				var responseInProgress = false;
 
-          self.messages.addMessage({
-            text: text,
-            textFooter: self.getTimestamp(),
-          });
+				$$('.send-link').on('click', function () {
+					var text = messagebar.getValue().replace(/\n/g, '<br>').trim();
+					if (!text.length) return;
 
-          if (responseInProgress) return;
+					messagebar.clear();
+					messagebar.focus();
 
-          app.aura.addMessageToChat({
-            text: text,
-            textFooter: self.getTimestamp(),
-            type: "sent"
-          })
+					self.messages.addMessage({
+						text: text,
+						textFooter: self.getTimestamp(),
+					});
 
-          if (!app.aura.getConsent()) {
-            self.askAuraConsent();
-            return;
-          }
-          
-          receiveMessage(text);
-        });       
+					if (responseInProgress) return;
 
-        async function receiveMessage(received) {
-          self.getAuraAnswer(received).then(data => {
-            responseInProgress = true;
-  
-            setTimeout(function () {
-              var answer = {
-                name : "Aura",
-                avatar : "static/images/aura/aura_icon.png",
-                type : "received",
-                text : data? data : "Desculpe, infelizmente eu não entendi",
-                textFooter : self.getTimestamp(),
-              }
+					app.aura.addMessageToChat({
+						text: text,
+						textFooter: self.getTimestamp(),
+						type: "sent"
+					})
 
-              app.aura.addMessageToChat(answer);
+					if (!app.aura.getConsent()) {
+						self.askAuraConsent();
+						return;
+					}
 
-              self.messages.showTyping({
-                header: answer.name + ' is typing',
-                avatar: answer.avatar
-              });
+					receiveMessage(text);
+				});
 
-              setTimeout(function () {
-                self.messages.addMessage(answer);
-                self.messages.hideTyping();
-                responseInProgress = false;
-              }, 1000);
-            }, 1000);
-          }); 
-        }
-        function loadOldMessages() {
-          let chat = app.aura.getChat();
+				async function receiveMessage(received) {
+					self.getAuraAnswer(received).then(data => {
+						responseInProgress = true;
 
-          if (!chat) {
-            receiveMessage("se apresente");
-            return;
-          }
+						setTimeout(function () {
+							var answer = {
+								name: "Aura",
+								avatar: "static/images/aura/aura_icon.png",
+								type: "received",
+								text: data ? data : "Desculpe, infelizmente eu não entendi",
+								textFooter: self.getTimestamp(),
+							}
 
-          for (let i = 0; i < chat.length; i++) {
-            self.messages.addMessage(chat[i]);
-          }
-          self.messages.scroll();
-        }
+							app.aura.addMessageToChat(answer);
 
-        loadOldMessages();
-      },
-      auraConsentAnswer: function (consent) {
-        var self = this;
-        var app = self.$app;
+							self.messages.showTyping({
+								header: answer.name + ' is typing',
+								avatar: answer.avatar
+							});
 
-        app.aura.setConsent(consent);
+							setTimeout(function () {
+								self.messages.addMessage(answer);
+								self.messages.hideTyping();
+								responseInProgress = false;
+							}, 1000);
+						}, 1000);
+					});
+				}
 
-        const consentButtons = document.querySelector('.aura-consent-buttons');
-        consentButtons.style.display = "none";
+				function loadOldMessages() {
+					let chat = app.aura.getChat();
 
-        if (!consent) {
-          self.messages.clear();
-          app.aura.clearChat();
-          this.messageInit();
-          return;
-        }
+					if (!chat) {
+						receiveMessage("se apresente");
+						return;
+					}
 
-        self.messages.addMessage({
-          text: "Concordo",
-          textFooter: self.getTimestamp(),
-        });
+					for (let i = 0; i < chat.length; i++) {
+						self.messages.addMessage(chat[i]);
+					}
+					self.messages.scroll();
+				}
 
-        app.aura.addMessageToChat({
-          text: "Concordo",
-          textFooter: self.getTimestamp(),
-          type: "sent"
-        });
+				loadOldMessages();
+			},
+			auraConsentAnswer: function (consent) {
+				var self = this;
+				var app = self.$app;
 
-        var answer = {
-          name: "Aura",
-          avatar: "static/images/aura/aura_icon.png",
-          type: "received",
-          text: "Ótimo, obrigada! Com o que eu posso ajudar hoje?",
-          textFooter: self.getTimestamp()
-        };
+				app.aura.setConsent(consent);
 
-        app.aura.addMessageToChat(answer);
-        
-        self.messages.showTyping({
-          header: answer.name + ' is typing',
-          avatar: answer.avatar
-        });
+				const consentButtons = document.querySelector('.aura-consent-buttons');
+				consentButtons.style.display = "none";
 
-        setTimeout(function () {
-          self.messages.addMessage(answer);
-          self.messages.hideTyping();   
-        }, 3000);
-      },
-      askAuraConsent: function () {
-        var self = this;
-        var app = self.$app
-        var answer = {
-          name: "Aura",
-          avatar: "static/images/aura/aura_icon.png",
-          type: "received",
-          text: "Para que eu consiga evoluir constantemente, todas as mensagens e interações que você fizer comigo são armazenadas em um banco de dados, na íntegra. As mensagens não estão associadas a você (a autoria é anonimizada). Você concorda com isso?",
-          textFooter: self.getTimestamp()
-        };
-        
-        app.aura.addMessageToChat(answer);
+				if (!consent) {
+					if (typeof cordova !== 'undefined') {
+						cordova.plugins.firebase.analytics.logEvent("aura", {"consent": false}).then(res => {
+							console.log(`[${res}] aura: consent=false`);
+						})
+					}
+					self.messages.clear();
+					app.aura.clearChat();
+					this.messageInit();
+					return;
+				}
+				if (typeof cordova !== 'undefined') {
+					cordova.plugins.firebase.analytics.logEvent("aura", {"consent": true}).then(res => {
+						console.log(`[${res}] aura: consent=true`);
+					})
+				}
 
-        self.messages.showTyping({
-          header: answer.name + ' is typing',
-          avatar: answer.avatar
-        });
+				self.messages.addMessage({
+					text: "Concordo",
+					textFooter: self.getTimestamp(),
+				});
 
-        setTimeout(function () {
-          self.messages.addMessage(answer);
-          self.messages.hideTyping();
-          const consentButtons = document.querySelector('.aura-consent-buttons');
-          consentButtons.style.display = "flex";
-        }, 1500);
-      },
-    },
-    on: {
-      tabInit: function (e, page) {
-        this.messageInit();
-        var self = this;
-        this.showButtons = false;
+				app.aura.addMessageToChat({
+					text: "Concordo",
+					textFooter: self.getTimestamp(),
+					type: "sent"
+				});
 
-        setTimeout(() => {
-          this.resizeMessagesContent();
-        }, 1000)
-        
-        window.onresize = function() {
-          self.resizeMessagesContent();
-          var doc = document.getElementsByClassName("messages-content")[0];
-          var maxScroll = Dom7(".messages").height();
-          doc.scrollTo({ top: maxScroll, behavior: 'smooth' });
-        }
-      },
-    },
-  };
+				var answer = {
+					name: "Aura",
+					avatar: "static/images/aura/aura_icon.png",
+					type: "received",
+					text: "Ótimo, obrigada! Com o que eu posso ajudar hoje?",
+					textFooter: self.getTimestamp()
+				};
+
+				app.aura.addMessageToChat(answer);
+
+				self.messages.showTyping({
+					header: answer.name + ' is typing',
+					avatar: answer.avatar
+				});
+
+				setTimeout(function () {
+					self.messages.addMessage(answer);
+					self.messages.hideTyping();
+				}, 3000);
+			},
+			askAuraConsent: function () {
+				var self = this;
+				var app = self.$app
+				var answer = {
+					name: "Aura",
+					avatar: "static/images/aura/aura_icon.png",
+					type: "received",
+					text: "Para que eu consiga evoluir constantemente, todas as mensagens e interações que você fizer comigo são armazenadas em um banco de dados, na íntegra. As mensagens não estão associadas a você (a autoria é anonimizada). Você concorda com isso?",
+					textFooter: self.getTimestamp()
+				};
+
+				app.aura.addMessageToChat(answer);
+
+				self.messages.showTyping({
+					header: answer.name + ' is typing',
+					avatar: answer.avatar
+				});
+
+				setTimeout(function () {
+					self.messages.addMessage(answer);
+					self.messages.hideTyping();
+					const consentButtons = document.querySelector('.aura-consent-buttons');
+					consentButtons.style.display = "flex";
+				}, 1500);
+			},
+		},
+		on: {
+			tabInit: function (e, page) {
+				this.messageInit();
+				var self = this;
+				this.showButtons = false;
+
+				setTimeout(() => {
+					this.resizeMessagesContent();
+				}, 1000)
+
+				window.onresize = function () {
+					self.resizeMessagesContent();
+					var doc = document.getElementsByClassName("messages-content")[0];
+					var maxScroll = Dom7(".messages").height();
+					doc.scrollTo({
+						top: maxScroll,
+						behavior: 'smooth'
+					});
+				}
+			},
+		},
+	};
 </script>


### PR DESCRIPTION
Nesta issue, foi realizado a integração do analytics no `app practice`.

O que acontece é que para dispositivos android, o melhor a ser feito é usar as informações de `google-services` que são utilizadas para as notificações `FCM` para trackear o aplicativo. Foi tentando de várias formas, até utilizando um plugin-cordova para utilização do google analytics, mas não funcinou. 

Nas pesquisas descobri que poderia usar o Firebase para conseguir os dados do analytics e vi que havia uma outra propriedade no analytics da conta do practice (practiceuffs@gmail.com). Mas quando observava o "Em tempo real" do analytics não aparecia as informações, então depois de um tempo utilizando, eu vi que tem um delay bem longo (diferente do trackeamento de desktop) para aparecer essas informações. Então, consegui encontrar formas de enviar eventos para o **Analytics** usando o **Firebase**. Atualizei o arquivo `abalytics.js` para uma classe e criei funções e triggers para lançar evento ao abrir uma `page` ou `tab`. Também criei um evento pra `aura`, que é disparado no pedido de consentimento e quando o usuário solicita uma resposta dela. Posteriormente dá pra avaliar mais eventos interessantes e podemos elencá-los como conversão no **Analytics**.

[Link do Analytics](https://analytics.google.com/analytics/web/#/p281903629/reports/intelligenthome?params=_u..nav%3Dmaui) -> Deve ser acessado pelo practiceuffs@gmail.com

Screenshot:
![image](https://user-images.githubusercontent.com/51202705/147093631-de9bf737-c417-41c3-baa1-d0d1665b669b.png)

Fix: #197 