### PR TITLE
feat: avaliação de respostas da Aura

### DIFF
--- a/src/js/aura.js
+++ b/src/js/aura.js
@@ -16,6 +16,21 @@ export class Aura{
         }).catch(err => err);
     }
 
+    async rateAnswer(answer, value) {
+        var self = this;
+        var app = self.app;
+        const data = {
+            "app_id": 4,
+            "action": "aura_feedback",
+            "key": answer,
+            "value": value   
+        }
+        return await app.request.promise.postJSON(app.api.url + "analytics", data)
+        .then(async () => {
+            return true;
+        }).catch(err => false);
+    }
+
     setConsent(consent) {
         localStorage["auraConsent"] = JSON.stringify(consent);
     }

--- a/src/js/aura.js
+++ b/src/js/aura.js
@@ -47,6 +47,10 @@ export class Aura{
         localStorage["auraChat"] =  JSON.stringify(chat);
     }
 
+    saveChat(chat) {
+        localStorage["auraChat"] =  JSON.stringify(chat);
+    }
+
     getChat() {
         let chat = JSON.parse(localStorage.getItem("auraChat"));
 		return chat;

--- a/src/pages/aura.f7.html
+++ b/src/pages/aura.f7.html
@@ -45,7 +45,7 @@
   }
   .message-footer {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     width: 100%;
   }
@@ -55,7 +55,6 @@
     width: fit-content;
     background-color: #fff;
     border: none
-
   }
 </style>
 
@@ -96,10 +95,10 @@
           var message = $$('.message-id-'+messageId+' .message-content .message-footer');
           if (e.target.value == 1) {
             self.messages.messages[messageId].footer = "Avalie a resposta <button class='rated-btn f7-icons' value='1' id='"+messageId+"'>hand_thumbsup</button>";
-            message.html("Avalie a resposta <button class='rated-btn f7-icons' value='1' id='"+messageId+"'>hand_thumbsup</button>");
+            message.html("<button class='rated-btn f7-icons' value='1' id='"+messageId+"'>hand_thumbsup</button>");
           } else {
             self.messages.messages[messageId].footer = "Avalie a resposta <button class='rated-btn f7-icons' value='-1' id='"+messageId+"'>hand_thumbsdown</button>";
-            message.html("Avalie a resposta <button class='rated-btn f7-icons' value='-1' id='"+messageId+"'>hand_thumbsdown</button>");
+            message.html("<button class='rated-btn f7-icons' value='-1' id='"+messageId+"'>hand_thumbsdown</button>");
           }
           app.aura.rateAnswer(self.messages.messages[messageId].text, e.target.value)
           .then((res) => {

--- a/src/pages/aura.f7.html
+++ b/src/pages/aura.f7.html
@@ -101,7 +101,12 @@
             self.messages.messages[messageId].footer = "Avalie a resposta <button class='rated-btn f7-icons' value='-1' id='"+messageId+"'>hand_thumbsdown</button>";
             message.html("Avalie a resposta <button class='rated-btn f7-icons' value='-1' id='"+messageId+"'>hand_thumbsdown</button>");
           }
-          app.aura.saveChat(self.messages.messages);
+          app.aura.rateAnswer(self.messages.messages[messageId].text, e.target.value)
+          .then((res) => {
+            if (res) {
+              app.aura.saveChat(self.messages.messages);
+            }
+          });
           self.changeRate();
         });  
         self.changeRate();

--- a/src/pages/aura.f7.html
+++ b/src/pages/aura.f7.html
@@ -43,6 +43,20 @@
     width: 100%;
     background-image: linear-gradient(to bottom, white, white, rgba(255,255,255,0.8),rgba(255,255,255,0));
   }
+  .message-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
+  .rating-btn {
+    margin: 0;
+    padding: 0 8px;
+    width: fit-content;
+    background-color: #fff;
+    border: none
+
+  }
 </style>
 
 <script>
@@ -71,6 +85,25 @@
           }
           return answer;
         });
+      },
+      rateAnswer: function () {
+        var $$ = Dom7;
+        var self = this;
+        var app = self.$app;
+        $$('.rating-btn').off('click');
+        $$('.rating-btn').on('click', function (e) {
+          var messageId = e.target.id;
+          var message = $$('.message-id-'+messageId+' .message-content .message-footer');
+          if (e.target.value == 1) {
+            self.messages.messages[messageId].footer = "Avalie a resposta <button class='rating-btn f7-icons' value='1'>hand_thumbsup</button>";
+            message.html("Avalie a resposta <button class='rating-btn f7-icons' value='1'>hand_thumbsup</button>");
+          } else {
+            self.messages.messages[messageId].footer = "Avalie a resposta <button class='rating-btn f7-icons' value='-1'>hand_thumbsdown</button>";
+            message.html("Avalie a resposta <button class='rating-btn f7-icons' value='-1'>hand_thumbsdown</button>");
+          }
+          app.aura.saveChat(self.messages.messages);
+          
+        });  
       },
       resizeMessagesContent: function (){
         let logoAura = Dom7('#logo_aura');
@@ -143,8 +176,8 @@
           }
           
           receiveMessage(text);
-        });       
-
+        });      
+        
         async function receiveMessage(received) {
           self.getAuraAnswer(received).then(data => {
             responseInProgress = true;
@@ -156,6 +189,8 @@
                 type : "received",
                 text : data? data : "Desculpe, infelizmente eu não entendi",
                 textFooter : self.getTimestamp(),
+                footer: "Avalie a resposta <button class='rating-btn f7-icons' id='"+self.messages.messages.length+"' value='1'>hand_thumbsup</button> <button class='rating-btn f7-icons' id='"+self.messages.messages.length+"' value='-1'>hand_thumbsdown</button>",
+                cssClass: "message-id-"+self.messages.messages.length
               }
 
               app.aura.addMessageToChat(answer);
@@ -167,6 +202,7 @@
 
               setTimeout(function () {
                 self.messages.addMessage(answer);
+                self.rateAnswer();
                 self.messages.hideTyping();
                 responseInProgress = false;
               }, 1000);
@@ -267,10 +303,13 @@
         this.messageInit();
         var self = this;
         this.showButtons = false;
+        var $$ = Dom7;
 
         setTimeout(() => {
           this.resizeMessagesContent();
         }, 1000)
+
+        this.rateAnswer();
         
         window.onresize = function() {
           self.resizeMessagesContent();

--- a/src/pages/aura.f7.html
+++ b/src/pages/aura.f7.html
@@ -49,7 +49,7 @@
     align-items: center;
     width: 100%;
   }
-  .rating-btn {
+  .rating-btn, .rated-btn {
     margin: 0;
     padding: 0 8px;
     width: fit-content;
@@ -95,15 +95,29 @@
           var messageId = e.target.id;
           var message = $$('.message-id-'+messageId+' .message-content .message-footer');
           if (e.target.value == 1) {
-            self.messages.messages[messageId].footer = "Avalie a resposta <button class='rating-btn f7-icons' value='1'>hand_thumbsup</button>";
-            message.html("Avalie a resposta <button class='rating-btn f7-icons' value='1'>hand_thumbsup</button>");
+            self.messages.messages[messageId].footer = "Avalie a resposta <button class='rated-btn f7-icons' value='1' id='"+messageId+"'>hand_thumbsup</button>";
+            message.html("Avalie a resposta <button class='rated-btn f7-icons' value='1' id='"+messageId+"'>hand_thumbsup</button>");
           } else {
-            self.messages.messages[messageId].footer = "Avalie a resposta <button class='rating-btn f7-icons' value='-1'>hand_thumbsdown</button>";
-            message.html("Avalie a resposta <button class='rating-btn f7-icons' value='-1'>hand_thumbsdown</button>");
+            self.messages.messages[messageId].footer = "Avalie a resposta <button class='rated-btn f7-icons' value='-1' id='"+messageId+"'>hand_thumbsdown</button>";
+            message.html("Avalie a resposta <button class='rated-btn f7-icons' value='-1' id='"+messageId+"'>hand_thumbsdown</button>");
           }
           app.aura.saveChat(self.messages.messages);
-          
+          self.changeRate();
         });  
+        self.changeRate();
+      },
+      changeRate: function () {
+        var $$ = Dom7;
+        var self = this;
+        var app = self.$app;
+        $$('.rated-btn').off('click');
+        $$('.rated-btn').on('click', function (e) {
+          var messageId = e.target.id;
+          self.messages.messages[messageId].footer = "Avalie a resposta <button class='rating-btn f7-icons' id='"+messageId+"' value='1'>hand_thumbsup</button> <button class='rating-btn f7-icons' id='"+messageId+"' value='-1'>hand_thumbsdown</button>";
+          $$('.message-id-'+messageId+' .message-content .message-footer').html("Avalie a resposta <button class='rating-btn f7-icons' id='"+messageId+"' value='1'>hand_thumbsup</button> <button class='rating-btn f7-icons' id='"+messageId+"' value='-1'>hand_thumbsdown</button>");
+          app.aura.saveChat(self.messages.messages);
+          self.rateAnswer();
+        }); 
       },
       resizeMessagesContent: function (){
         let logoAura = Dom7('#logo_aura');


### PR DESCRIPTION
Adicionei botões para que seja possível avaliar as respostas da Aura:

![image](https://user-images.githubusercontent.com/51202548/147244251-53186981-ef1b-483a-a7a1-649e34c2df36.png)

![image](https://user-images.githubusercontent.com/51202548/147244271-42605ea3-cedb-42a9-bc7d-27763cbcb86e.png)

É possível reavaliar a resposta ao clicar novamente no botão. As avaliações estão sendo enviadas para o endpoint `v0/analytics` como solicitado mas ainda não é possível testar plenamente o funcionamento do envio pois o endpoint ainda não foi criado na API.

Fix: #199 